### PR TITLE
Remove support for Ruby 2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,4 +40,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              ruby-version: ["2.6.5", "2.7.1", "2.7.3"]
+              ruby-version: ["2.7.1", "2.7.3"]


### PR DESCRIPTION
After upgrading the investapp to [Ruby 2.7](https://github.com/sharesight/investapp/pull/8245) we don't need to run builds for Ruby 2.6 anymore or even support it altogether.