### PR TITLE
Raise errors on deprecation warnings

### DIFF
--- a/jemquarie.gemspec
+++ b/jemquarie.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", '~> 11.2'
   spec.add_development_dependency "rspec", '~> 3.4'
   spec.add_development_dependency "rubocop", '1.18.1'
+  spec.add_development_dependency "warning"
   spec.add_development_dependency "webmock", '~> 3.3'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,4 +20,7 @@ RSpec.configure do |config|
   config.order = 'random'
 end
 
+# Requiring custom test helpers
+Dir["#{File.dirname(__FILE__)}/spec_helpers/*.rb"].sort.each { |f| require File.expand_path(f) }
+
 WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/spec_helpers/warning_spec_helper.rb
+++ b/spec/spec_helpers/warning_spec_helper.rb
@@ -1,0 +1,10 @@
+require 'warning'
+
+Warning.process do |warning|
+  case warning
+  when /warning:/
+    :raise
+  else
+    :default
+  end
+end

--- a/spec/spec_helpers/warning_spec_helper.rb
+++ b/spec/spec_helpers/warning_spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'warning'
 
 Warning.process do |warning|


### PR DESCRIPTION
Ruby 2.7 introduced a couple of deprecation warnings around [positional and keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/), in preparation for Ruby 3. So far we only showed the deprecation warning (when running tests for example). Not anymore, because we missed some of them already. We now raise an exception in that case, so you have to fix them before they sneak into investapp.