### PR TITLE
Bump activesupport to '~> 6.1', '>= 6.1.4.7'

### DIFF
--- a/jemquarie.gemspec
+++ b/jemquarie.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", '~> 6.0.0'
+  spec.add_runtime_dependency "activesupport", '~> 6.1', '>= 6.1.4.4'
   spec.add_runtime_dependency "savon", '~> 2.12'
 
   spec.add_development_dependency "rake", '~> 11.2'

--- a/jemquarie.gemspec
+++ b/jemquarie.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", '~> 6.1', '>= 6.1.4.6'
+  spec.add_runtime_dependency "activesupport", '~> 6.1', '>= 6.1.4.7'
   spec.add_runtime_dependency "savon", '~> 2.12'
 
   spec.add_development_dependency "rake", '~> 11.2'

--- a/jemquarie.gemspec
+++ b/jemquarie.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", '~> 6.1', '>= 6.1.4.4'
+  spec.add_runtime_dependency "activesupport", '~> 6.1', '>= 6.1.4.6'
   spec.add_runtime_dependency "savon", '~> 2.12'
 
   spec.add_development_dependency "rake", '~> 11.2'


### PR DESCRIPTION
Part of work to upgrade to Rails ~6.1.4.4~ 6.1.4.6.