### PR TITLE
Add Slack notification to Ga workflows

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -27,3 +27,16 @@ jobs:
 
     - name: Run rubocop
       run: bundle exec rubocop --parallel
+
+    - name: Slack notification
+      if: success() || failure()
+      uses: rtCamp/action-slack-notify@v2
+      env:
+         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+         SLACK_CHANNEL: "ci-${{ github.event.repository.name }}"
+         SLACK_COLOR: ${{ job.status }} # automatic colour based on job status
+         SLACK_ICON_EMOJI: ':sharesight_cat:'
+         SLACK_TITLE: "Linter run with Rubocop *${{ job.status }}* (by ${{ github.actor }})"
+         SLACK_USERNAME: GA rubocop
+         SLACK_FOOTER: ''
+         MSG_MINIMAL: actions url,commit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,3 +31,16 @@ jobs:
 
     - name: Run tests
       run: bundle exec rake test
+
+    - name: Slack notification
+      if: success() || failure()
+      uses: rtCamp/action-slack-notify@v2
+      env:
+         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+         SLACK_CHANNEL: "ci-${{ github.event.repository.name }}"
+         SLACK_COLOR: ${{ job.status }} # automatic colour based on job status
+         SLACK_ICON_EMOJI: ':sharesight_cat:'
+         SLACK_TITLE: "Test run with ruby ${{matrix.ruby-version}} *${{ job.status }}* (by ${{ github.actor }})"
+         SLACK_USERNAME: GA tests
+         SLACK_FOOTER: ''
+         MSG_MINIMAL: actions url,commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+ * Add Slack notification to GA workflows [#15](https://github.com/sharesight/jemquarie/pull/15)
+ * Run tests and Rubocop with Github Actions [#14](https://github.com/sharesight/jemquarie/pull/14)
+
 ## 1.4.3 (`15/03/2022`)
+ * Address CircleCI Ruby image deprecation [#13](https://github.com/sharesight/jemquarie/pull/13)
  * Bump activerecord to "~> 6.1", ">= 6.1.4.7" to support Rails 6.1 upgrade [#12](https://github.com/sharesight/jemquarie/pull/12)
  * Raise errors on deprecation warnings, added frozen string literal [#11](https://github.com/sharesight/jemquarie/pull/11)
  * Remove support for Ruby 2.6 [#10](https://github.com/sharesight/jemquarie/pull/10)


### PR DESCRIPTION
### 📝 Description

Public fork; did not realise it was possible to have Slack notifications before.

<img width="631" alt="Screen Shot 2022-07-28 at 11 18 08" src="https://user-images.githubusercontent.com/2127023/181388671-530a33f4-ee7d-417c-88aa-d1db072ea20c.png">

No story.

----

Related:
- (public repo) https://github.com/sharesight/flappi/pull/56
- (public fork) https://github.com/sharesight/jemquarie/pull/15 (this PR)
- (public fork) https://github.com/sharesight/encrypted_strings/pull/8