### PR TITLE
Update TLS version to 1.2

### DIFF
--- a/lib/jemquarie/base.rb
+++ b/lib/jemquarie/base.rb
@@ -16,7 +16,7 @@ module Jemquarie
         log_level   Jemquarie.log_level
         log Jemquarie.log_requests
         logger Jemquarie.logger if Jemquarie.logger
-        ssl_version :TLSv1
+        ssl_version :TLSv1_2
       end
     end
 


### PR DESCRIPTION
Macquarie will soon be deprecating support for TLS 1.0 and 1.1.

I would choose the latest version of TLS, 1.3, but it appears that Savon doesn't currently recognise it as an option for the `ssl_version`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202844940537337