### PR TITLE
Don't use Rack v3.0.0 in Jemquarie

### DIFF
--- a/jemquarie.gemspec
+++ b/jemquarie.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activesupport", '~> 6.1', '>= 6.1.4.7'
-  spec.add_runtime_dependency "rack", '~> 2.2.0', '< 3.0.0'
+  spec.add_runtime_dependency "rack", '~> 2.2'
   spec.add_runtime_dependency "savon", '~> 2.12'
 
   spec.add_development_dependency "rake", '~> 11.2'

--- a/jemquarie.gemspec
+++ b/jemquarie.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activesupport", '~> 6.1', '>= 6.1.4.7'
-  spec.add_runtime_dependency "savon", '~> 2.12'
   spec.add_runtime_dependency "rack", '~> 2.2.0', '< 3.0.0'
+  spec.add_runtime_dependency "savon", '~> 2.12'
 
   spec.add_development_dependency "rake", '~> 11.2'
   spec.add_development_dependency "rspec", '~> 3.4'

--- a/jemquarie.gemspec
+++ b/jemquarie.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "activesupport", '~> 6.1', '>= 6.1.4.7'
   spec.add_runtime_dependency "savon", '~> 2.12'
+  spec.add_runtime_dependency "rack", '~> 2.2.0', '< 3.0.0'
 
   spec.add_development_dependency "rake", '~> 11.2'
   spec.add_development_dependency "rspec", '~> 3.4'


### PR DESCRIPTION
Very recently, [Rack got an upgrade to v3.0.0](https://github.com/rack/rack/tags). Our CI for jemquarie uses this version of rack which includes a deprecation warning for the use of `Rack::Utils::HeaderHash` and causes [tests to fail](https://github.com/sharesight/jemquarie/runs/8217878260). We shouldn't see this deprecation warning in investapp right now because we still use a lower version.

This PR just updates the gemspec for jemquarie so that we force a rack version under v3.