### PR TITLE
Update `jemquarie` dependencies for Rails 7.1

### DIFF
--- a/jemquarie.gemspec
+++ b/jemquarie.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", '~> 7.0.8'
+  spec.add_runtime_dependency "activesupport", '~> 7.1.0'
   spec.add_runtime_dependency "rack", '~> 2.2'
   spec.add_runtime_dependency "savon", '~> 2.12'
 

--- a/jemquarie.gemspec
+++ b/jemquarie.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", '~> 7.1.0'
+  spec.add_runtime_dependency "activesupport", ">= 7.0", "< 7.2"
   spec.add_runtime_dependency "rack", '~> 2.2'
   spec.add_runtime_dependency "savon", '~> 2.12'
 


### PR DESCRIPTION
## Description
We want upgrade _investapp_ to Rails 7.1, and therefore need to update the `jemquarie` gem's dependencies accordingly. It now supports both Rails versions 7.0 and 7.1 .

See [Asana ticket](https://app.asana.com/0/1202486819364117/1207407464892063).