### PR TITLE
Bump active support to v8.0 for jemquarie

### DIFF
--- a/jemquarie.gemspec
+++ b/jemquarie.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", '~> 8.0'
+  spec.add_runtime_dependency "activesupport", ">= 7.0", "< 8.1"
   spec.add_runtime_dependency "rack", '~> 2.2'
   spec.add_runtime_dependency "savon", '~> 2.12'
 

--- a/jemquarie.gemspec
+++ b/jemquarie.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", ">= 7.0", "< 8"
+  spec.add_runtime_dependency "activesupport", '~> 8.0'
   spec.add_runtime_dependency "rack", '~> 2.2'
   spec.add_runtime_dependency "savon", '~> 2.12'
 


### PR DESCRIPTION
investapp uses the jemquarie gem which depends on`activerecord` which are locked to version 7.2 currently in investapp.

In order to upgrade to rails 8.0 we need to bump these dependencies to the latest version.

Will keep this in it's own branch for now and merge when required, master once the upgrade is ready to go. Since this version would not work with the currently live version of investapp

[Asana task](https://app.asana.com/1/1200581835983208/project/1209777270020565/task/1211111000546620?focus=true)