### PR TITLE
Don't run ruby 3.1 tests for jemquarie

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.1.4', '3.3.0']
+        ruby-version: ['3.3.0']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Currently for this gem we always run tests for both ruby version 3.3 and 3.1.

We have already upgraded to version 3.3 so the need to run 3.1 tests is not needed anymore. Breaks when you try to upgrade active support to >= 8.0