### PR TITLE
Relax rack constraint to support rack 3.x

### DIFF
--- a/jemquarie.gemspec
+++ b/jemquarie.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activesupport", ">= 7.0", "< 8"
-  spec.add_runtime_dependency "rack", '~> 2.2'
+  spec.add_runtime_dependency "rack", '>= 2.2', '< 4'
   spec.add_runtime_dependency "savon", '~> 2.12'
 
   spec.add_development_dependency "rake"

--- a/jemquarie.gemspec
+++ b/jemquarie.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activesupport", ">= 7.0", "< 8.1"
-  spec.add_runtime_dependency "rack", '>= 2.2', '< 4'
   spec.add_runtime_dependency "savon", '~> 2.12'
 
   spec.add_development_dependency "rake"


### PR DESCRIPTION
## Description
httpi 4.0.x (already a dependency via savon) removed the Rack::Utils::HeaderHash usage that previously blocked rack 3 support.

This change is a requirement for https://github.com/sharesight/investapp/pull/16288 .